### PR TITLE
Fix parallel test.

### DIFF
--- a/02ab_pca.R
+++ b/02ab_pca.R
@@ -82,7 +82,8 @@ eigenRandData = eigen(Srand)$values
 
 # How many eigen values of the real data are
 # above their random counterparts?
-sum(eigenRandData < eigenData) 
+# sum(eigenRandData < eigenData) 
+min(which(eigenRandData >= eigenData)) - 1
 # Uncomment and replace nFac if you want to overwrite
 # the EKC result and use a different number of factors
 # nFac <- 9999


### PR DESCRIPTION
In particular for pupil data sometimes the eigenRandData is lower than eigenData for a large number of higher components (presumably due to numerical imprecision). Our parallel test then gives (grossly) incorrect results. I tried to fix, not sure whether this is an optimal solution.